### PR TITLE
fix: replacement new domain

### DIFF
--- a/src/core/network/api/client.ts
+++ b/src/core/network/api/client.ts
@@ -3,7 +3,7 @@ import createDebug from 'debug';
 const debug = createDebug('one-me:client');
 
 const defaultOptions = {
-  baseUrl: 'https://botapi.max.ru',
+  baseUrl: 'https://platform-api.max.ru',
 } as const;
 
 export type ClientOptions = Partial<typeof defaultOptions>;


### PR DESCRIPTION
Согласно документации для стабильной работы ботов нужно перейти на новый домен platform-api.max.ru.