### PR TITLE
feat: sessions, scenes, wizard, router, format helpers, advanced composer

### DIFF
--- a/examples/session-bot.ts
+++ b/examples/session-bot.ts
@@ -1,0 +1,88 @@
+/**
+ * Session Bot
+ *
+ * Demonstrates ctx.session and ctx.state:
+ * - Counts total messages per user via session (persisted across updates)
+ * - Measures middleware execution time via ctx.state (per-update)
+ *
+ * Usage:
+ *   BOT_TOKEN=<token> npx ts-node examples/session-bot.ts
+ */
+
+import { Bot, Context, session, MemorySessionStore } from '@maxhub/max-bot-api';
+
+// ─── Session shape ────────────────────────────────────────────────────────────
+
+interface MySession {
+  messageCount: number;
+  lastText: string | null;
+}
+
+// ─── Extended context ─────────────────────────────────────────────────────────
+
+type MyContext = Context & { session: MySession };
+
+// ─── Bootstrap ────────────────────────────────────────────────────────────────
+
+const token = process.env.BOT_TOKEN;
+if (!token) throw new Error('BOT_TOKEN is not set');
+
+const bot = new Bot<MyContext>(token);
+
+// ─── Middleware: timing via ctx.state ─────────────────────────────────────────
+
+bot.use((ctx, next) => {
+  ctx.state.startedAt = Date.now();
+  return next();
+});
+
+// ─── Session (per-user, in memory with 1-hour TTL) ────────────────────────────
+
+const store = new MemorySessionStore<MySession>(60 * 60 * 1000);
+
+bot.use(
+  session<MySession, MyContext>({
+    store,
+    defaultSession: () => ({ messageCount: 0, lastText: null }),
+  }),
+);
+
+// ─── Commands ─────────────────────────────────────────────────────────────────
+
+bot.command('start', (ctx) =>
+  ctx.reply('Привет! Отправь мне любое сообщение, и я буду его считать.'),
+);
+
+bot.command('stats', async (ctx) => {
+  const { messageCount, lastText } = ctx.session;
+  await ctx.reply(
+    `📊 Статистика:\n` +
+    `• Сообщений: ${messageCount}\n` +
+    `• Последнее: ${lastText ?? '—'}`,
+  );
+});
+
+bot.command('reset', async (ctx) => {
+  ctx.session.messageCount = 0;
+  ctx.session.lastText = null;
+  await ctx.reply('Счётчик сброшен.');
+});
+
+// ─── Message handler ──────────────────────────────────────────────────────────
+
+bot.on('message_created', async (ctx) => {
+  const text = ctx.message?.body.text ?? '';
+  ctx.session.messageCount++;
+  ctx.session.lastText = text.slice(0, 80);
+
+  const elapsed = Date.now() - (ctx.state.startedAt as number);
+
+  await ctx.reply(
+    `Сообщение #${ctx.session.messageCount} получено за ${elapsed} мс\n` +
+    `Текст: "${text}"`,
+  );
+});
+
+// ─── Start ────────────────────────────────────────────────────────────────────
+
+bot.start();

--- a/examples/wizard-bot.ts
+++ b/examples/wizard-bot.ts
@@ -1,0 +1,115 @@
+/**
+ * Wizard Bot — Registration Flow
+ *
+ * Demonstrates WizardScene for a multi-step form:
+ *   /register → (name) → (phone) → confirmation → done
+ *
+ * Usage:
+ *   BOT_TOKEN=<token> npx ts-node examples/wizard-bot.ts
+ */
+
+import {
+  Bot,
+  Context,
+  session,
+  Stage,
+  WizardScene,
+  WizardContextWizard,
+  type SceneContextScene,
+  type WizardSession,
+  type WizardSessionData,
+} from '@maxhub/max-bot-api';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface RegistrationData {
+  name?: string;
+  phone?: string;
+}
+
+type MyContext = Context & {
+  session: WizardSession;
+  scene: SceneContextScene<MyContext, WizardSessionData>;
+  wizard: WizardContextWizard<MyContext>;
+};
+
+// ─── Bootstrap ────────────────────────────────────────────────────────────────
+
+const token = process.env.BOT_TOKEN;
+if (!token) throw new Error('BOT_TOKEN is not set');
+
+// ─── Wizard scene (3 steps) ───────────────────────────────────────────────────
+
+const registration = new WizardScene<MyContext>(
+  'registration',
+
+  // Шаг 0 — запрашиваем имя
+  async (ctx) => {
+    await ctx.reply('Шаг 1/2 — Введите ваше имя:');
+    ctx.wizard.next();
+  },
+
+  // Шаг 1 — запрашиваем телефон
+  async (ctx) => {
+    const name = ctx.message?.body.text;
+    if (!name) {
+      await ctx.reply('Пожалуйста, введите имя текстом.');
+      return; // остаёмся на этом шаге
+    }
+    (ctx.wizard.state as RegistrationData).name = name;
+    await ctx.reply('Шаг 2/2 — Введите ваш телефон:');
+    ctx.wizard.next();
+  },
+
+  // Шаг 2 — завершение
+  async (ctx) => {
+    const phone = ctx.message?.body.text;
+    if (!phone) {
+      await ctx.reply('Пожалуйста, введите телефон текстом.');
+      return;
+    }
+    const data = ctx.wizard.state as RegistrationData;
+    data.phone = phone;
+
+    await ctx.reply(
+      `✅ Регистрация завершена!\n\n` +
+      `Имя: ${data.name}\n` +
+      `Телефон: ${data.phone}`,
+    );
+    await ctx.scene.leave();
+  },
+);
+
+// Enter/leave hooks
+registration.enter((ctx) => {
+  console.log(`User ${ctx.user?.user_id} entered registration wizard`);
+});
+
+registration.leave((ctx) => {
+  console.log(`User ${ctx.user?.user_id} left registration wizard`);
+});
+
+// ─── Stage ────────────────────────────────────────────────────────────────────
+
+const stage = new Stage<MyContext>([registration]);
+
+// ─── Bot ─────────────────────────────────────────────────────────────────────
+
+const bot = new Bot<MyContext>(token);
+
+bot.use(session());
+bot.use(stage);
+
+bot.command('register', (ctx) => ctx.scene.enter('registration'));
+bot.command('cancel', (ctx) => ctx.scene.leave());
+
+bot.command('start', (ctx) =>
+  ctx.reply('Привет!\n\n/register — начать регистрацию\n/cancel — отменить'),
+);
+
+// Catch-all: напомнить пользователю вне сцены
+bot.on('message_created', (ctx) =>
+  ctx.reply('Введите /register чтобы начать, или /cancel для отмены.'),
+);
+
+bot.start();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxhub/max-bot-api",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Max Bot Framework",
   "repository": "https://github.com/max-messenger/max-bot-api-client-ts",
   "author": "Juice Development",
@@ -36,20 +36,20 @@
   },
   "devDependencies": {
     "@types/debug": "^4.1.12",
-    "@types/node": "^22.5.5",
+    "@types/node": "^25.4.0",
     "@types/vcf": "^2.0.7",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
-    "eslint": "^8.2.0",
+    "eslint": "^8.57.1",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-config-airbnb-typescript": "^18.0.0",
-    "eslint-plugin-import": "^2.25.2",
+    "eslint-plugin-import": "^2.32.0",
     "mit-license": "^1.0.0",
-    "nodemon": "^3.1.7",
-    "typescript": "^5.4.2"
+    "nodemon": "^3.1.14",
+    "typescript": "^5.9.3"
   },
   "dependencies": {
-    "debug": "^4.3.7",
+    "debug": "^4.4.3",
     "vcf": "^2.1.2"
   }
 }

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -1,4 +1,4 @@
-import type { Guard, MaybeArray } from './core/helpers/types';
+import type { Guard, MaybeArray, MaybePromise } from './core/helpers/types';
 import type { Message, UpdateType } from './core/network/api';
 
 import type {
@@ -8,9 +8,17 @@ import type {
 import { Context, type FilteredContext } from './context';
 import { createdMessageBodyHas } from './filters';
 
-type Triggers = MaybeArray<string | RegExp>;
+/** Context-aware trigger function: receives matched string and context, returns match or null. */
+export type TriggerFn<Ctx extends Context> = (value: string, ctx: Ctx) => RegExpExecArray | null;
+
+export type Triggers<Ctx extends Context = Context> = MaybeArray<string | RegExp | TriggerFn<Ctx>>;
+
+export type Predicate<T> = (t: T) => boolean;
+export type AsyncPredicate<T> = (t: T) => Promise<boolean>;
 
 type UpdateFilter<Ctx extends Context> = UpdateType | Guard<Ctx['update']>;
+
+const noopAsync = () => Promise.resolve();
 
 export class Composer<Ctx extends Context> implements MiddlewareObj<Ctx> {
   private handler: MiddlewareFn<Ctx>;
@@ -36,21 +44,21 @@ export class Composer<Ctx extends Context> implements MiddlewareObj<Ctx> {
   }
 
   command(
-    command: Triggers,
+    command: Triggers<FilteredContext<Ctx, 'message_created'>>,
     ...middlewares: Array<Middleware<FilteredContext<Ctx, 'message_created'>>>
   ) {
     const normalizedTriggers = normalizeTriggers(command);
-    const filter = createdMessageBodyHas('text');
+    const filterFn = createdMessageBodyHas('text');
 
     const handler = Composer.compose(middlewares);
 
-    return this.use(this.filter(filter, (ctx, next) => {
+    return this.use(this.filter(filterFn, (ctx, next) => {
       const text = extractTextFromMessage(ctx.message, ctx.myId)!;
 
       const cmd = text.slice(1);
 
       for (const trigger of normalizedTriggers) {
-        const match = trigger(cmd);
+        const match = trigger(cmd, ctx as unknown as FilteredContext<Ctx, 'message_created'>);
         if (match) {
           ctx.match = match;
           return handler(ctx, next);
@@ -62,19 +70,19 @@ export class Composer<Ctx extends Context> implements MiddlewareObj<Ctx> {
   }
 
   hears(
-    triggers: Triggers,
+    triggers: Triggers<FilteredContext<Ctx, 'message_created'>>,
     ...middlewares: Array<Middleware<FilteredContext<Ctx, 'message_created'>>>
   ) {
     const normalizedTriggers = normalizeTriggers(triggers);
-    const filter = createdMessageBodyHas('text');
+    const filterFn = createdMessageBodyHas('text');
 
     const handler = Composer.compose(middlewares);
 
-    return this.use(this.filter(filter, (ctx, next) => {
+    return this.use(this.filter(filterFn, (ctx, next) => {
       const text = extractTextFromMessage(ctx.message, ctx.myId)!;
 
       for (const trigger of normalizedTriggers) {
-        const match = trigger(text);
+        const match = trigger(text, ctx as unknown as FilteredContext<Ctx, 'message_created'>);
         if (match) {
           ctx.match = match;
           return handler(ctx, next);
@@ -86,7 +94,7 @@ export class Composer<Ctx extends Context> implements MiddlewareObj<Ctx> {
   }
 
   action(
-    triggers: Triggers,
+    triggers: Triggers<FilteredContext<Ctx, 'message_callback'>>,
     ...middlewares: Array<Middleware<FilteredContext<Ctx, 'message_callback'>>>
   ) {
     const normalizedTriggers = normalizeTriggers(triggers);
@@ -98,7 +106,7 @@ export class Composer<Ctx extends Context> implements MiddlewareObj<Ctx> {
       if (!payload) return next();
 
       for (const trigger of normalizedTriggers) {
-        const match = trigger(payload);
+        const match = trigger(payload, ctx as unknown as FilteredContext<Ctx, 'message_callback'>);
         if (match) {
           ctx.match = match;
           return handler(ctx, next);
@@ -119,10 +127,72 @@ export class Composer<Ctx extends Context> implements MiddlewareObj<Ctx> {
     };
   }
 
+  /** Drops updates matching the predicate (they don't propagate further). */
+  drop(predicate: Predicate<Ctx>) {
+    return this.use(Composer.drop(predicate));
+  }
+
+  /** Runs middleware in the background without blocking the main chain. */
+  fork(middleware: Middleware<Ctx>) {
+    return this.use(Composer.fork(middleware));
+  }
+
+  /** Runs middleware as a side-effect: awaits it, then always calls next. */
+  tap(middleware: Middleware<Ctx>) {
+    return this.use(Composer.tap(middleware));
+  }
+
+  /** Lazily creates middleware from a factory function on each update. */
+  lazy(factoryFn: (ctx: Ctx) => MaybePromise<Middleware<Ctx>>) {
+    return this.use(Composer.lazy(factoryFn));
+  }
+
+  /** Runs trueMiddleware or falseMiddleware based on predicate. */
+  branch(
+    predicate: boolean | Predicate<Ctx> | AsyncPredicate<Ctx>,
+    trueMiddleware: Middleware<Ctx>,
+    falseMiddleware: Middleware<Ctx>,
+  ) {
+    return this.use(Composer.branch(predicate, trueMiddleware, falseMiddleware));
+  }
+
+  /** Runs middlewares only when predicate is true; otherwise passes through. */
+  optional(
+    predicate: Predicate<Ctx> | AsyncPredicate<Ctx>,
+    ...middlewares: Array<Middleware<Ctx>>
+  ) {
+    return this.use(Composer.optional(predicate, ...middlewares));
+  }
+
+  /** Dispatches to one of the provided handlers based on a routing function. */
+  dispatch<Handlers extends Record<string | number | symbol, Middleware<Ctx>>>(
+    routeFn: (ctx: Ctx) => MaybePromise<keyof Handlers>,
+    handlers: Handlers,
+  ) {
+    return this.use(Composer.dispatch(routeFn, handlers));
+  }
+
+  /** Shorthand for `command('help', ...middlewares)`. */
+  help(...middlewares: Array<Middleware<FilteredContext<Ctx, 'message_created'>>>) {
+    return this.command('help', ...middlewares);
+  }
+
+  /** Shorthand for `command('settings', ...middlewares)`. */
+  settings(...middlewares: Array<Middleware<FilteredContext<Ctx, 'message_created'>>>) {
+    return this.command('settings', ...middlewares);
+  }
+
+  // ─── Static factories ────────────────────────────────────────────────
+
   static flatten<C extends Context>(mw: Middleware<C>): MiddlewareFn<C> {
     return typeof mw === 'function'
       ? mw
       : (ctx, next) => mw.middleware()(ctx, next);
+  }
+
+  /** Alias of `flatten` — unwraps a Middleware into a plain MiddlewareFn. */
+  static unwrap<C extends Context>(mw: Middleware<C>): MiddlewareFn<C> {
+    return Composer.flatten(mw);
   }
 
   static concat<C extends Context>(
@@ -145,7 +215,12 @@ export class Composer<Ctx extends Context> implements MiddlewareObj<Ctx> {
     return next();
   }
 
-  static compose<C extends Context>(middlewares: Array<Middleware<C>>) {
+  /** A no-op pass-through middleware (alias of `pass` as a factory). */
+  static passThru<C extends Context = Context>(): MiddlewareFn<C> {
+    return (_ctx, next) => next();
+  }
+
+  static compose<C extends Context>(middlewares: Array<Middleware<C>>): MiddlewareFn<C> {
     if (!Array.isArray(middlewares)) {
       throw new Error('Middlewares must be an array');
     }
@@ -154,19 +229,121 @@ export class Composer<Ctx extends Context> implements MiddlewareObj<Ctx> {
     }
     return middlewares.map(Composer.flatten).reduce(Composer.concat);
   }
+
+  /** Runs middleware in the background (fire-and-forget). */
+  static fork<C extends Context>(middleware: Middleware<C>): MiddlewareFn<C> {
+    const handler = Composer.flatten(middleware);
+    return async (ctx, next) => {
+      await Promise.all([handler(ctx, noopAsync), next()]);
+    };
+  }
+
+  /** Runs middleware as a side-effect then always continues. */
+  static tap<C extends Context>(middleware: Middleware<C>): MiddlewareFn<C> {
+    const handler = Composer.flatten(middleware);
+    return (ctx, next) =>
+      Promise.resolve(handler(ctx, noopAsync)).then(() => next());
+  }
+
+  /** Creates middleware lazily from a factory called once per update. */
+  static lazy<C extends Context>(
+    factoryFn: (ctx: C) => MaybePromise<Middleware<C>>,
+  ): MiddlewareFn<C> {
+    if (typeof factoryFn !== 'function') {
+      throw new Error('Argument must be a function');
+    }
+    return (ctx, next) =>
+      Promise.resolve(factoryFn(ctx)).then((mw) =>
+        Composer.flatten(mw)(ctx, next),
+      );
+  }
+
+  /** Logs each update as JSON using `logFn` (defaults to `console.log`). */
+  static log(logFn: (s: string) => void = console.log): MiddlewareFn<Context> {
+    return (ctx, next) => {
+      logFn(JSON.stringify(ctx.update, null, 2));
+      return next();
+    };
+  }
+
+  /**
+   * Wraps `fns` in a try/catch; calls `errorHandler` on rejection.
+   * Execution continues normally after error handling.
+   */
+  static catch<C extends Context>(
+    errorHandler: (err: unknown, ctx: C) => MaybePromise<void>,
+    ...fns: Array<Middleware<C>>
+  ): MiddlewareFn<C> {
+    const handler = Composer.compose(fns);
+    return (ctx, next) =>
+      Promise.resolve(handler(ctx, next)).catch((err: unknown) =>
+        errorHandler(err, ctx),
+      );
+  }
+
+  /** Runs trueMiddleware or falseMiddleware based on a (possibly async) predicate. */
+  static branch<C extends Context>(
+    predicate: boolean | Predicate<C> | AsyncPredicate<C>,
+    trueMiddleware: Middleware<C>,
+    falseMiddleware: Middleware<C>,
+  ): MiddlewareFn<C> {
+    if (typeof predicate !== 'function') {
+      return Composer.flatten(predicate ? trueMiddleware : falseMiddleware);
+    }
+    return Composer.lazy<C>((ctx) =>
+      Promise.resolve(predicate(ctx)).then((value) =>
+        value ? trueMiddleware : falseMiddleware,
+      ),
+    );
+  }
+
+  /** Runs middlewares when predicate is truthy; otherwise passes through. */
+  static optional<C extends Context>(
+    predicate: Predicate<C> | AsyncPredicate<C>,
+    ...fns: Array<Middleware<C>>
+  ): MiddlewareFn<C> {
+    return Composer.branch(predicate, Composer.compose(fns), Composer.passThru<C>());
+  }
+
+  /** Drops matching updates (does NOT call next). */
+  static drop<C extends Context>(predicate: Predicate<C>): MiddlewareFn<C> {
+    return Composer.branch(predicate, noopAsync, Composer.passThru<C>());
+  }
+
+  /** Routes to one of the `handlers` based on the key returned by `routeFn`. */
+  static dispatch<
+    C extends Context,
+    Handlers extends Record<string | number | symbol, Middleware<C>>,
+  >(
+    routeFn: (ctx: C) => MaybePromise<keyof Handlers>,
+    handlers: Handlers,
+  ): Middleware<C> {
+    return Composer.lazy<C>((ctx) =>
+      Promise.resolve(routeFn(ctx)).then((key) => handlers[key]),
+    );
+  }
+
+  /** Creates a reply middleware with fixed arguments. */
+  static reply(...args: Parameters<Context['reply']>): MiddlewareFn<Context> {
+    return (ctx) => ctx.reply(...args);
+  }
 }
 
-const normalizeTriggers = (triggers: Triggers) => {
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const normalizeTriggers = <Ctx extends Context>(triggers: Triggers<Ctx>) => {
   return (Array.isArray(triggers) ? triggers : [triggers]).map((trigger) => {
+    if (typeof trigger === 'function') {
+      return trigger;
+    }
     if (trigger instanceof RegExp) {
-      return (value = '') => {
-        // eslint-disable-next-line no-param-reassign
+      return (value = '', _ctx: Ctx) => {
         trigger.lastIndex = 0;
         return trigger.exec(value.trim());
       };
     }
     const regex = new RegExp(`^${trigger}$`);
-    return (value: string) => regex.exec(value.trim());
+    return (value: string, _ctx: Ctx) => regex.exec(value.trim());
   });
 };
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -89,6 +89,9 @@ type Sticker = {
 export class Context<U extends Update = Update> {
   match?: RegExpExecArray;
 
+  /** Arbitrary state storage shared across middleware chain */
+  state: Record<string | symbol, unknown> = {};
+
   constructor(
     readonly update: U,
     readonly api: Api,

--- a/src/core/helpers/keyboard.ts
+++ b/src/core/helpers/keyboard.ts
@@ -1,12 +1,80 @@
 import { InlineKeyboardAttachmentRequest } from '../network/api';
+import type { Button } from '../network/api';
 
-export const inlineKeyboard = (
-  buttons: InlineKeyboardAttachmentRequest['payload']['buttons'],
-): InlineKeyboardAttachmentRequest => {
+// ─── Button row helpers ────────────────────────────────────────────────────────
+
+type Hideable<B extends Button> = B & { hide?: boolean };
+type HideableButton = Hideable<Button>;
+
+interface KeyboardBuildingOptions<B extends HideableButton> {
+  /** Custom wrap predicate: return `true` to start a new row before `btn`. */
+  wrap?: (btn: B, index: number, currentRow: B[]) => boolean;
+  /** Maximum buttons per row when no `wrap` function is given. Defaults to 1. */
+  columns?: number;
+}
+
+function is2D<B>(arr: B[] | B[][]): arr is B[][] {
+  return Array.isArray(arr[0]);
+}
+
+/**
+ * Converts a flat or already-2D button array into a filtered 2D array.
+ *
+ * Buttons with `hide: true` are always excluded.
+ */
+function buildKeyboard<B extends HideableButton>(
+  buttons: B[] | B[][],
+  options: Required<Pick<KeyboardBuildingOptions<B>, 'columns'>> & Pick<KeyboardBuildingOptions<B>, 'wrap'>,
+): B[][] {
+  if (!Array.isArray(buttons) || buttons.length === 0) return [];
+
+  if (is2D(buttons)) {
+    return buttons.map((row) => row.filter((btn) => !btn.hide));
+  }
+
+  const visible = buttons.filter((btn) => !btn.hide);
+  const wrapFn = options.wrap
+    ?? ((_btn: B, _i: number, row: B[]) => row.length >= options.columns);
+
+  const result: B[][] = [];
+  let currentRow: B[] = [];
+
+  visible.forEach((btn, idx) => {
+    if (wrapFn(btn, idx, currentRow) && currentRow.length > 0) {
+      result.push(currentRow);
+      currentRow = [];
+    }
+    currentRow.push(btn);
+  });
+
+  if (currentRow.length > 0) result.push(currentRow);
+  return result;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/** Create an inline keyboard from a pre-built 2D button array. */
+export function inlineKeyboard(
+  buttons: HideableButton[][],
+): InlineKeyboardAttachmentRequest;
+/** Create an inline keyboard from a flat array, auto-split into rows. */
+export function inlineKeyboard(
+  buttons: HideableButton[],
+  options?: KeyboardBuildingOptions<HideableButton>,
+): InlineKeyboardAttachmentRequest;
+export function inlineKeyboard(
+  buttons: HideableButton[] | HideableButton[][],
+  options?: KeyboardBuildingOptions<HideableButton>,
+): InlineKeyboardAttachmentRequest {
+  const cols = options?.columns ?? (is2D(buttons) ? undefined : buttons.length);
+  const grid = buildKeyboard(buttons as HideableButton[], {
+    columns: cols ?? buttons.length,
+    wrap: options?.wrap,
+  });
   return {
     type: 'inline_keyboard',
-    payload: { buttons },
+    payload: { buttons: grid as Button[][] },
   };
-};
+}
 
 export * as button from './buttons';

--- a/src/core/helpers/upload.ts
+++ b/src/core/helpers/upload.ts
@@ -81,7 +81,7 @@ async function uploadRangeChunk({
 }: UploadRangeChunkParams, { signal }: { signal?: AbortSignal } = {}) {
   const uploadRes = await fetch(uploadUrl, {
     method: 'POST',
-    body: chunk,
+    body: typeof chunk === 'string' ? chunk : new Uint8Array(chunk),
     headers: {
       'Content-Disposition': `attachment; filename="${fileName}"`,
       'Content-Range': `bytes ${startByte}-${endByte}/${fileSize}`,
@@ -188,7 +188,7 @@ export class Upload {
       };
     }
 
-    if (source instanceof Buffer) {
+    if (Buffer.isBuffer(source)) {
       return {
         buffer: source,
         fileName: randomUUID(),
@@ -271,7 +271,7 @@ export class Upload {
     token?: string,
   }): Promise<Res> => {
     const formData = new FormData();
-    formData.append('data', new Blob([file.buffer]), file.fileName);
+    formData.append('data', new Blob([new Uint8Array(file.buffer)]), file.fileName);
 
     const res = await fetch(uploadUrl, {
       method: 'POST',

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -1,6 +1,9 @@
 import type {
-  MessageBody, MessageCreatedUpdate, Update,
+  MessageBody, MessageCallbackUpdate, MessageCreatedUpdate,
+  MessageEditedUpdate, Update,
 } from './core/network/api';
+
+import type { Guard } from './core/helpers/types';
 
 export const createdMessageBodyHas = <Keys extends Array<keyof MessageBody>>(...keys: Keys) => {
   return (update: Update): update is MessageCreatedUpdate => {
@@ -12,3 +15,39 @@ export const createdMessageBodyHas = <Keys extends Array<keyof MessageBody>>(...
     return true;
   };
 };
+
+/** Matches `message_edited` updates. */
+export const messageEdited = (update: Update): update is MessageEditedUpdate =>
+  update.update_type === 'message_edited';
+
+/** Matches `message_callback` updates. */
+export const messageCallback = (update: Update): update is MessageCallbackUpdate =>
+  update.update_type === 'message_callback';
+
+/**
+ * Logical OR — passes the update if at least one filter matches.
+ *
+ * @example
+ * bot.on(anyOf('message_created', 'message_edited'), handler)
+ */
+export const anyOf = <U extends Update>(
+  ...filters: Array<Guard<Update, U> | Update['update_type']>
+): Guard<Update, U> =>
+  (update): update is U =>
+    filters.some((f) =>
+      typeof f === 'function' ? f(update) : update.update_type === f,
+    );
+
+/**
+ * Logical AND — passes the update only when all filters match.
+ *
+ * @example
+ * bot.on(allOf(messageEdited, createdMessageBodyHas('text')), handler)
+ */
+export const allOf = <U extends Update>(
+  ...filters: Array<Guard<Update, U> | Update['update_type']>
+): Guard<Update, U> =>
+  (update): update is U =>
+    filters.every((f) =>
+      typeof f === 'function' ? f(update) : update.update_type === f,
+    );

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,90 @@
+/**
+ * Formatting helpers for the Max Bot API.
+ *
+ * Generates strings in Max markdown (format: 'markdown') or HTML
+ * (format: 'html') notation.  Pass the result as the `text` argument and
+ * add the corresponding `format` value to `SendMessageExtra`.
+ *
+ * @example
+ * import * as fmt from './format'
+ *
+ * // Markdown
+ * ctx.reply(fmt.bold('Hello') + ' world', { format: 'markdown' })
+ *
+ * // HTML
+ * ctx.reply(fmt.boldHtml('Hello') + ' world', { format: 'html' })
+ */
+
+// ─── Markdown helpers ─────────────────────────────────────────────────────────
+
+/** Wraps text in **bold** markdown. */
+export const bold = (text: string): string => `**${text}**`;
+
+/** Wraps text in _italic_ markdown. */
+export const italic = (text: string): string => `_${text}_`;
+
+/** Wraps text in ~~strikethrough~~ markdown. */
+export const strikethrough = (text: string): string => `~~${text}~~`;
+
+/** Wraps text in inline `code` markdown. */
+export const code = (text: string): string => `\`${text}\``;
+
+/**
+ * Wraps text in a fenced code block markdown.
+ * @param language Optional syntax-highlighting language hint.
+ */
+export const pre = (text: string, language = ''): string =>
+  language
+    ? `\`\`\`${language}\n${text}\n\`\`\``
+    : `\`\`\`\n${text}\n\`\`\``;
+
+/** Creates a markdown inline link: `[text](url)`. */
+export const link = (text: string, url: string): string => `[${text}](${url})`;
+
+/**
+ * Escapes all characters that have special meaning in Max markdown.
+ * Use this on user-supplied strings before embedding them into formatted text.
+ */
+export const escape = (text: string): string =>
+  text.replace(/([_*[\]()~`>#+=|{}.!\\-])/g, '\\$1');
+
+// ─── HTML helpers ─────────────────────────────────────────────────────────────
+
+/** Wraps text in `<b>…</b>` HTML bold tags. */
+export const boldHtml = (text: string): string => `<b>${text}</b>`;
+
+/** Wraps text in `<i>…</i>` HTML italic tags. */
+export const italicHtml = (text: string): string => `<i>${text}</i>`;
+
+/** Wraps text in `<u>…</u>` HTML underline tags. */
+export const underlineHtml = (text: string): string => `<u>${text}</u>`;
+
+/** Wraps text in `<s>…</s>` HTML strikethrough tags. */
+export const strikethroughHtml = (text: string): string => `<s>${text}</s>`;
+
+/** Wraps text in `<code>…</code>` HTML inline code tags. */
+export const codeHtml = (text: string): string => `<code>${text}</code>`;
+
+/**
+ * Wraps text in `<pre>…</pre>` HTML pre-formatted block.
+ * @param language If provided, wraps content in `<code class="language-…">`.
+ */
+export const preHtml = (text: string, language = ''): string =>
+  language
+    ? `<pre><code class="language-${language}">${text}</code></pre>`
+    : `<pre>${text}</pre>`;
+
+/** Creates an HTML anchor tag: `<a href="url">text</a>`. */
+export const linkHtml = (text: string, url: string): string =>
+  `<a href="${url}">${text}</a>`;
+
+/**
+ * Escapes characters that must be escaped inside HTML text content.
+ * Use this on user-supplied strings before embedding them into HTML-formatted text.
+ */
+export const escapeHtml = (text: string): string =>
+  text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { Api } from './api';
 export { Bot } from './bot';
 export { Composer } from './composer';
+export type { Triggers, TriggerFn, Predicate, AsyncPredicate } from './composer';
 export { Context } from './context';
 export type { FilteredContext } from './context';
 
@@ -15,3 +16,46 @@ export {
 } from './core/helpers/attachments';
 export * as Keyboard from './core/helpers/keyboard';
 export { MaxError } from './core/network/api';
+
+// ─── Session ──────────────────────────────────────────────────────────────────
+export {
+  session,
+  MemorySessionStore,
+  type SyncSessionStore,
+  type AsyncSessionStore,
+  type SessionStore,
+  type SessionContext,
+} from './session';
+
+// ─── Scenes ───────────────────────────────────────────────────────────────────
+export {
+  Stage,
+  BaseScene,
+  SceneContextScene,
+  WizardScene,
+  WizardContextWizard,
+  type SceneOptions,
+  type SceneContext,
+  type SceneSession,
+  type SceneSessionData,
+  type SceneContextSceneOptions,
+  type WizardContext,
+  type WizardSession,
+  type WizardSessionData,
+} from './scenes';
+
+// ─── Router ───────────────────────────────────────────────────────────────────
+export { Router } from './router';
+
+// ─── Filters ──────────────────────────────────────────────────────────────────
+export {
+  createdMessageBodyHas,
+  messageEdited,
+  messageCallback,
+  anyOf,
+  allOf,
+} from './filters';
+
+// ─── Format helpers ───────────────────────────────────────────────────────────
+export * as fmt from './format';
+

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,70 @@
+import { Composer } from './composer';
+import type { Middleware, MiddlewareObj } from './middleware';
+import { Context } from './context';
+
+type NonemptyReadonlyArray<T> = readonly [T, ...T[]];
+
+/** Return value of the routing function: identifies a handler and optional state patch. */
+type RouteResult = {
+  route: string;
+  /** Optional state values to merge into `ctx.state`. */
+  state?: Record<string | symbol, unknown>;
+};
+
+type RouteFn<C extends Context> = (ctx: C) => RouteResult | null;
+
+/**
+ * Route-based middleware dispatcher.
+ *
+ * @example
+ * const router = new Router<MyCtx>((ctx) => {
+ *   if (ctx.updateType === 'message_created') return { route: 'message' }
+ *   return null
+ * })
+ * router.on('message', (ctx) => ctx.reply('got a message'))
+ * router.otherwise((ctx) => ctx.reply('unknown update'))
+ * bot.use(router)
+ */
+export class Router<C extends Context> implements MiddlewareObj<C> {
+  private otherwiseHandler: Middleware<C> = Composer.passThru<C>();
+
+  constructor(
+    private readonly routeFn: RouteFn<C>,
+    public readonly handlers = new Map<string, Middleware<C>>(),
+  ) {
+    if (typeof routeFn !== 'function') {
+      throw new Error('Router: routing function is required');
+    }
+  }
+
+  /** Register a handler for the given route name. */
+  on(route: string, ...fns: NonemptyReadonlyArray<Middleware<C>>) {
+    if (fns.length === 0) {
+      throw new TypeError('Router.on: at least one handler is required');
+    }
+    this.handlers.set(route, Composer.compose([...fns]));
+    return this;
+  }
+
+  /** Fallback handler used when no route matches or `routeFn` returns `null`. */
+  otherwise(...fns: NonemptyReadonlyArray<Middleware<C>>) {
+    if (fns.length === 0) {
+      throw new TypeError('Router.otherwise: at least one handler is required');
+    }
+    this.otherwiseHandler = Composer.compose([...fns]);
+    return this;
+  }
+
+  middleware() {
+    return Composer.lazy<C>((ctx) => {
+      const result = this.routeFn(ctx);
+      if (result == null) {
+        return this.otherwiseHandler;
+      }
+      if (result.state) {
+        Object.assign(ctx.state, result.state);
+      }
+      return this.handlers.get(result.route) ?? this.otherwiseHandler;
+    });
+  }
+}

--- a/src/scenes/base.ts
+++ b/src/scenes/base.ts
@@ -1,0 +1,61 @@
+import { Composer } from '../composer';
+import type { Middleware, MiddlewareFn } from '../middleware';
+import type { Context } from '../context';
+
+export interface SceneOptions<C extends Context> {
+  /** Auto-leave TTL in seconds. */
+  ttl?: number;
+  handlers?: ReadonlyArray<MiddlewareFn<C>>;
+  enterHandlers?: ReadonlyArray<MiddlewareFn<C>>;
+  leaveHandlers?: ReadonlyArray<MiddlewareFn<C>>;
+}
+
+/**
+ * A named scene that participates in the middleware composition system.
+ *
+ * Extend this class or use it directly.  Register instances with `Stage`.
+ */
+export class BaseScene<C extends Context = Context> extends Composer<C> {
+  readonly id: string;
+
+  ttl?: number;
+
+  enterHandler: MiddlewareFn<C>;
+
+  leaveHandler: MiddlewareFn<C>;
+
+  constructor(id: string, options?: SceneOptions<C>) {
+    const opts: Required<SceneOptions<C>> = {
+      handlers: [],
+      enterHandlers: [],
+      leaveHandlers: [],
+      ttl: undefined as unknown as number,
+      ...options,
+    };
+    super(...(opts.handlers as Middleware<C>[]));
+    this.id = id;
+    this.ttl = opts.ttl;
+    this.enterHandler = Composer.compose(opts.enterHandlers as Middleware<C>[]);
+    this.leaveHandler = Composer.compose(opts.leaveHandlers as Middleware<C>[]);
+  }
+
+  /** Register handlers that run when the scene is entered. */
+  enter(...fns: Array<Middleware<C>>) {
+    this.enterHandler = Composer.compose([this.enterHandler, ...fns]);
+    return this;
+  }
+
+  /** Register handlers that run when the scene is left. */
+  leave(...fns: Array<Middleware<C>>) {
+    this.leaveHandler = Composer.compose([this.leaveHandler, ...fns]);
+    return this;
+  }
+
+  enterMiddleware(): MiddlewareFn<C> {
+    return this.enterHandler;
+  }
+
+  leaveMiddleware(): MiddlewareFn<C> {
+    return this.leaveHandler;
+  }
+}

--- a/src/scenes/context.ts
+++ b/src/scenes/context.ts
@@ -1,0 +1,148 @@
+import createDebug from 'debug';
+import { Composer } from '../composer';
+import type { BaseScene } from './base';
+import type { Context } from '../context';
+import type { SessionContext } from '../session';
+
+const debug = createDebug('max:scenes:context');
+
+const noop = () => Promise.resolve();
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface SceneSessionData {
+  /** ID of the currently active scene. */
+  current?: string;
+  /** Unix timestamp (seconds) after which the session expires. */
+  expires?: number;
+  /** Arbitrary state passed between scene steps. */
+  state?: Record<string, unknown>;
+}
+
+export interface SceneSession<S extends SceneSessionData = SceneSessionData> {
+  __scenes?: S;
+}
+
+export interface SceneContextSceneOptions<D extends SceneSessionData> {
+  ttl?: number;
+  /** Scene ID used when no other scene is active. */
+  default?: string;
+  defaultSession: D;
+}
+
+export interface SceneContext<D extends SceneSessionData = SceneSessionData>
+  extends Context {
+  session: SceneSession<D>;
+  scene: SceneContextScene<SceneContext<D>, D>;
+}
+
+// ─── Scene controller (lives on ctx.scene) ────────────────────────────────────
+
+export class SceneContextScene<
+  C extends SessionContext<SceneSession<D>>,
+  D extends SceneSessionData = SceneSessionData,
+> {
+  private readonly options: SceneContextSceneOptions<D>;
+
+  constructor(
+    private readonly ctx: C,
+    private readonly scenes: Map<string, BaseScene<C>>,
+    options: Partial<SceneContextSceneOptions<D>>,
+  ) {
+    const fallback = {} as D;
+    this.options = { defaultSession: fallback, ...options };
+  }
+
+  get session(): D {
+    const defaultSession = { ...this.options.defaultSession };
+
+    let session = this.ctx.session?.__scenes ?? defaultSession;
+    if (session.expires !== undefined && session.expires < nowSec()) {
+      session = defaultSession;
+    }
+    if (this.ctx.session === undefined) {
+      this.ctx.session = { __scenes: session };
+    } else {
+      this.ctx.session.__scenes = session;
+    }
+    return session;
+  }
+
+  get state(): Record<string, unknown> {
+    return (this.session.state ??= {});
+  }
+
+  set state(value: Record<string, unknown>) {
+    this.session.state = { ...value };
+  }
+
+  /** The currently active scene, or `undefined` when none is active. */
+  get current(): BaseScene<C> | undefined {
+    const sceneId = this.session.current ?? this.options.default;
+    if (sceneId === undefined || !this.scenes.has(sceneId)) return undefined;
+    return this.scenes.get(sceneId);
+  }
+
+  /** Clears scene session data. */
+  reset() {
+    if (this.ctx.session !== undefined) {
+      this.ctx.session.__scenes = { ...this.options.defaultSession };
+    }
+  }
+
+  async enter(sceneId: string, initialState: Record<string, unknown> = {}, silent = false) {
+    if (!this.scenes.has(sceneId)) {
+      throw new Error(`Max: can't find scene "${sceneId}"`);
+    }
+    if (!silent) {
+      await this.leave();
+    }
+    debug('Entering scene %s (silent=%s)', sceneId, silent);
+    this.session.current = sceneId;
+    this.state = initialState;
+
+    const ttl = this.current?.ttl ?? this.options.ttl;
+    if (ttl !== undefined) {
+      this.session.expires = nowSec() + ttl;
+    }
+
+    if (this.current === undefined || silent) return;
+
+    const scene = this.current;
+    const handler =
+      typeof scene.enterMiddleware === 'function'
+        ? scene.enterMiddleware()
+        : scene.middleware();
+
+    return await handler(this.ctx, noop);
+  }
+
+  reenter() {
+    return this.session.current === undefined
+      ? undefined
+      : this.enter(this.session.current, this.state);
+  }
+
+  private leaving = false;
+
+  async leave() {
+    if (this.leaving) return;
+    debug('Leaving scene');
+    try {
+      this.leaving = true;
+      if (this.current === undefined) return;
+
+      const scene = this.current;
+      const handler =
+        typeof scene.leaveMiddleware === 'function'
+          ? scene.leaveMiddleware()
+          : Composer.passThru<C>();
+
+      await handler(this.ctx, noop);
+      this.reset();
+    } finally {
+      this.leaving = false;
+    }
+  }
+}

--- a/src/scenes/index.ts
+++ b/src/scenes/index.ts
@@ -1,0 +1,17 @@
+export { Stage } from './stage';
+export { BaseScene } from './base';
+export type { SceneOptions } from './base';
+export {
+  SceneContextScene,
+  type SceneContext,
+  type SceneSession,
+  type SceneSessionData,
+  type SceneContextSceneOptions,
+} from './context';
+export { WizardScene } from './wizard';
+export {
+  WizardContextWizard,
+  type WizardContext,
+  type WizardSession,
+  type WizardSessionData,
+} from './wizard/context';

--- a/src/scenes/stage.ts
+++ b/src/scenes/stage.ts
@@ -1,0 +1,79 @@
+import { Composer } from '../composer';
+import { BaseScene } from './base';
+import { SceneContextScene, type SceneSession, type SceneSessionData } from './context';
+import type { SessionContext } from '../session';
+import type { Context } from '../context';
+
+/**
+ * Scene manager middleware.
+ *
+ * @example
+ * const greeter = new BaseScene<MyCtx>('greeter')
+ * greeter.enter((ctx) => ctx.reply('Welcome!'))
+ * greeter.on('message_created', (ctx) => ctx.scene.leave())
+ *
+ * const stage = new Stage<MyCtx>([greeter])
+ * bot.use(session())
+ * bot.use(stage)
+ * bot.command('start', (ctx) => ctx.scene.enter('greeter'))
+ */
+export class Stage<
+  C extends SessionContext<SceneSession<D>> & {
+    scene: SceneContextScene<C, D>;
+  },
+  D extends SceneSessionData = SceneSessionData,
+> extends Composer<C> {
+  scenes: Map<string, BaseScene<C>>;
+
+  constructor(
+    scenes: ReadonlyArray<BaseScene<C>> = [],
+    public readonly options: Partial<{ ttl: number; default: string }> = {},
+  ) {
+    super();
+    this.scenes = new Map<string, BaseScene<C>>();
+    scenes.forEach((scene) => this.register(scene));
+  }
+
+  /** Add a scene to the registry. */
+  register(...scenes: ReadonlyArray<BaseScene<C>>) {
+    scenes.forEach((scene) => {
+      if (scene?.id == null || typeof scene.middleware !== 'function') {
+        throw new Error('Stage: unsupported scene object');
+      }
+      this.scenes.set(scene.id, scene);
+    });
+    return this;
+  }
+
+  middleware() {
+    const handler = Composer.compose<C>([
+      (ctx, next) => {
+        ctx.scene = new SceneContextScene<C, D>(ctx, this.scenes, this.options);
+        return next();
+      },
+      super.middleware(),
+      Composer.lazy<C>((ctx) => ctx.scene.current ?? Composer.passThru<C>()),
+    ]);
+    // Only activate when ctx.session exists.
+    return Composer.optional<C>(
+      (ctx): ctx is C => 'session' in ctx,
+      handler,
+    );
+  }
+
+  // ─── Static shortcuts ───────────────────────────────────────────────
+
+  static enter<C extends Context & { scene: SceneContextScene<C> }>(
+    ...args: Parameters<SceneContextScene<C>['enter']>
+  ) {
+    return (ctx: C) => ctx.scene.enter(...args);
+  }
+
+  static reenter<C extends Context & { scene: SceneContextScene<C> }>() {
+    return (ctx: C) => ctx.scene.reenter();
+  }
+
+  static leave<C extends Context & { scene: SceneContextScene<C> }>() {
+    return (ctx: C) => ctx.scene.leave();
+  }
+}

--- a/src/scenes/wizard/context.ts
+++ b/src/scenes/wizard/context.ts
@@ -1,0 +1,68 @@
+import type { SceneContextScene, SceneSession, SceneSessionData } from '../context';
+import type { Context } from '../../context';
+import type { Middleware } from '../../middleware';
+import type { SessionContext } from '../../session';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface WizardSessionData extends SceneSessionData {
+  cursor: number;
+}
+
+export interface WizardSession<S extends WizardSessionData = WizardSessionData>
+  extends SceneSession<S> {}
+
+export interface WizardContext<D extends WizardSessionData = WizardSessionData>
+  extends Context {
+  session: WizardSession<D>;
+  scene: SceneContextScene<WizardContext<D>, D>;
+  wizard: WizardContextWizard<WizardContext<D>>;
+}
+
+// ─── Wizard step cursor ────────────────────────────────────────────────────────
+
+export class WizardContextWizard<
+  C extends SessionContext<WizardSession> & {
+    scene: SceneContextScene<C, WizardSessionData>;
+  },
+> {
+  /** Shared state object (same reference as `ctx.scene.state`). */
+  readonly state: Record<string, unknown>;
+
+  constructor(
+    private readonly ctx: C,
+    private readonly steps: ReadonlyArray<Middleware<C>>,
+  ) {
+    this.state = ctx.scene.state;
+    this.cursor = ctx.scene.session.cursor ?? 0;
+  }
+
+  /** The middleware for the current step, or `undefined` if the wizard is done. */
+  get step(): Middleware<C> | undefined {
+    return this.steps[this.cursor];
+  }
+
+  get cursor(): number {
+    return this.ctx.scene.session.cursor;
+  }
+
+  set cursor(cursor: number) {
+    this.ctx.scene.session.cursor = cursor;
+  }
+
+  /** Jump to a specific step by index. */
+  selectStep(index: number) {
+    this.cursor = index;
+    return this;
+  }
+
+  /** Advance to the next step. */
+  next() {
+    return this.selectStep(this.cursor + 1);
+  }
+
+  /** Go back to the previous step. */
+  back() {
+    return this.selectStep(this.cursor - 1);
+  }
+}

--- a/src/scenes/wizard/index.ts
+++ b/src/scenes/wizard/index.ts
@@ -1,0 +1,71 @@
+import { BaseScene, type SceneOptions } from '../base';
+import { Composer } from '../../composer';
+import type { Context } from '../../context';
+import type { Middleware, MiddlewareObj } from '../../middleware';
+import type { SceneContextScene } from '../context';
+import { WizardContextWizard, type WizardSessionData } from './context';
+
+/**
+ * A multi-step scene where each update is handled by the current "step".
+ *
+ * @example
+ * const wizard = new WizardScene<MyCtx>(
+ *   'form',
+ *   (ctx) => { await ctx.reply('Step 1: Enter your name'); ctx.wizard.next() },
+ *   (ctx) => { await ctx.reply(`Hello ${ctx.message?.body?.text}`); ctx.scene.leave() },
+ * )
+ */
+export class WizardScene<
+  C extends Context & {
+    scene: SceneContextScene<C, WizardSessionData>;
+    wizard: WizardContextWizard<C>;
+  },
+>
+  extends BaseScene<C>
+  implements MiddlewareObj<C>
+{
+  steps: Array<Middleware<C>>;
+
+  constructor(id: string, ...steps: Array<Middleware<C>>);
+  constructor(id: string, options: SceneOptions<C>, ...steps: Array<Middleware<C>>);
+  constructor(
+    id: string,
+    optionsOrFirstStep: SceneOptions<C> | Middleware<C>,
+    ...rest: Array<Middleware<C>>
+  ) {
+    let opts: SceneOptions<C> | undefined;
+    let steps: Array<Middleware<C>>;
+
+    if (typeof optionsOrFirstStep === 'function' || 'middleware' in optionsOrFirstStep) {
+      opts = undefined;
+      steps = [optionsOrFirstStep as Middleware<C>, ...rest];
+    } else {
+      opts = optionsOrFirstStep as SceneOptions<C>;
+      steps = rest;
+    }
+
+    super(id, opts);
+    this.steps = steps;
+  }
+
+  middleware() {
+    return Composer.compose<C>([
+      (ctx, next) => {
+        ctx.wizard = new WizardContextWizard<C>(ctx, this.steps);
+        return next();
+      },
+      super.middleware(),
+      (ctx, next) => {
+        if (ctx.wizard.step === undefined) {
+          ctx.wizard.selectStep(0);
+          return ctx.scene.leave();
+        }
+        return Composer.flatten(ctx.wizard.step)(ctx, next);
+      },
+    ]);
+  }
+
+  enterMiddleware() {
+    return Composer.compose([this.enterHandler, this.middleware()]);
+  }
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,0 +1,195 @@
+import createDebug from 'debug';
+import { Context } from './context';
+import type { MaybePromise } from './core/helpers/types';
+import type { MiddlewareFn } from './middleware';
+
+const debug = createDebug('max:session');
+
+// ─── Store interfaces ─────────────────────────────────────────────────────────
+
+export interface SyncSessionStore<T> {
+  get: (name: string) => T | undefined;
+  set: (name: string, value: T) => void;
+  delete: (name: string) => void;
+}
+
+export interface AsyncSessionStore<T> {
+  get: (name: string) => Promise<T | undefined>;
+  set: (name: string, value: T) => Promise<unknown>;
+  delete: (name: string) => Promise<unknown>;
+}
+
+export type SessionStore<T> = SyncSessionStore<T> | AsyncSessionStore<T>;
+
+// ─── Options ──────────────────────────────────────────────────────────────────
+
+type ExclusiveKeys<A, B> = keyof Omit<A, keyof B>;
+
+interface SessionOptions<S, C extends Context, P extends string> {
+  /**
+   * Property name on `ctx` where the session will be stored.
+   * Defaults to `"session"` → available as `ctx.session`.
+   */
+  property?: P;
+  /** Function to compute the session key for a given context. */
+  getSessionKey?: (ctx: C) => MaybePromise<string | undefined>;
+  /** Storage backend. Defaults to an in-memory store. */
+  store?: SessionStore<S>;
+  /** Factory for creating a fresh session when none exists. */
+  defaultSession?: (ctx: C) => S;
+}
+
+export interface SessionContext<S extends object> extends Context {
+  session?: S;
+}
+
+// ─── Middleware factory ───────────────────────────────────────────────────────
+
+/**
+ * Returns middleware that adds `ctx.session` for storing per-user state.
+ *
+ * Default key: `"${user_id}:${chat_id}"`. When either is missing the session
+ * property is set to `undefined` and the update is passed through unchanged.
+ *
+ * @example
+ * interface MySession { count: number }
+ * type MyCtx = Context & { session: MySession }
+ *
+ * const bot = new Bot<MyCtx>(token)
+ * bot.use(session<MySession, MyCtx>({ defaultSession: () => ({ count: 0 }) }))
+ * bot.on('message_created', (ctx) => { ctx.session.count++ })
+ */
+export function session<
+  S extends NonNullable<C[P]>,
+  C extends Context & { [key in P]?: C[P] },
+  P extends (ExclusiveKeys<C, Context> & string) | 'session' = 'session',
+>(options?: SessionOptions<S, C, P>): MiddlewareFn<C> {
+  const prop = options?.property ?? ('session' as P);
+  const getSessionKey = options?.getSessionKey ?? defaultGetSessionKey as (ctx: C) => MaybePromise<string | undefined>;
+  const store: SessionStore<S> = options?.store ?? new MemorySessionStore<S>();
+
+  // In-memory cache shared across concurrent updates for the same key.
+  const cache = new Map<string, { ref?: S; counter: number }>();
+  // Deduplicates simultaneous store.get() calls for the same key.
+  const concurrents = new Map<string, MaybePromise<S | undefined>>();
+
+  return async (ctx, next) => {
+    const updId = `${ctx.update.update_type}:${ctx.update.timestamp}`;
+    let released = false;
+
+    function releaseChecks() {
+      if (released && process.env.EXPERIMENTAL_SESSION_CHECKS) {
+        throw new Error(
+          'Session was accessed after the middleware chain exhausted. '
+          + "You're probably missing an `await` somewhere.",
+        );
+      }
+    }
+
+    const key = await getSessionKey(ctx);
+    if (!key) {
+      (ctx as Record<string, unknown>)[prop] = undefined;
+      return await next();
+    }
+
+    let cached = cache.get(key);
+    if (cached) {
+      debug(`(${updId}) found cached session, reusing`);
+      ++cached.counter;
+    } else {
+      debug(`(${updId}) cache miss`);
+      let promise = concurrents.get(key);
+      if (!promise) {
+        debug(`(${updId}) fetching from store`);
+        promise = store.get(key);
+      } else {
+        debug(`(${updId}) reusing concurrent fetch`);
+      }
+      concurrents.set(key, promise);
+      const upstream = await promise;
+      concurrents.delete(key);
+
+      const existing = cache.get(key);
+      if (existing) {
+        existing.counter++;
+        cached = existing;
+      } else {
+        cached = { ref: upstream ?? options?.defaultSession?.(ctx), counter: 1 };
+        cache.set(key, cached);
+      }
+    }
+
+    const c = cached;
+    let touched = false;
+
+    Object.defineProperty(ctx, prop, {
+      configurable: true,
+      enumerable: true,
+      get() {
+        releaseChecks();
+        touched = true;
+        return c.ref;
+      },
+      set(value: S) {
+        releaseChecks();
+        touched = true;
+        c.ref = value;
+      },
+    });
+
+    try {
+      await next();
+      released = true;
+    } finally {
+      if (--c.counter === 0) {
+        debug(`(${updId}) refcount=0, purging cache entry`);
+        cache.delete(key);
+      }
+      if (touched) {
+        if (c.ref == null) {
+          debug(`(${updId}) session deleted, removing from store`);
+          await store.delete(key);
+        } else {
+          debug(`(${updId}) session touched, updating store`);
+          await store.set(key, c.ref);
+        }
+      }
+    }
+  };
+}
+
+// ─── Defaults ─────────────────────────────────────────────────────────────────
+
+function defaultGetSessionKey(ctx: Context): string | undefined {
+  const userId = ctx.user?.user_id;
+  const chatId = ctx.chatId;
+  if (userId == null || chatId == null) return undefined;
+  return `${userId}:${chatId}`;
+}
+
+// ─── In-memory store with optional TTL ────────────────────────────────────────
+
+export class MemorySessionStore<T> implements SyncSessionStore<T> {
+  private readonly store = new Map<string, { session: T; expires: number }>();
+
+  /** @param ttl Milliseconds until a session entry expires. Defaults to `Infinity`. */
+  constructor(private readonly ttl = Infinity) {}
+
+  get(name: string): T | undefined {
+    const entry = this.store.get(name);
+    if (entry == null) return undefined;
+    if (entry.expires < Date.now()) {
+      this.delete(name);
+      return undefined;
+    }
+    return entry.session;
+  }
+
+  set(name: string, value: T): void {
+    this.store.set(name, { session: value, expires: Date.now() + this.ttl });
+  }
+
+  delete(name: string): void {
+    this.store.delete(name);
+  }
+}


### PR DESCRIPTION
# feat: sessions, scenes, wizard, router, format helpers, advanced composer

## Summary

Brings the library feature set up to parity with mature Bot Framework implementations.
All additions are **backwards-compatible** — nothing in the existing public API changed.
No new production dependencies were introduced.

Inspired by and architecturally aligned with [Telegraf](https://github.com/telegraf/telegraf),
adapted to the Max Bot API update model (`update_type` string discriminant, marker-based polling,
Max-specific attachment/keyboard types).

---

## What's new

### `ctx.state`

Arbitrary per-update key–value store shared across the entire middleware chain.
Supports both string and symbol keys.

```ts
bot.use((ctx, next) => {
  ctx.state.startedAt = Date.now()
  return next()
})
bot.on('message_created', (ctx) => {
  console.log('elapsed:', Date.now() - (ctx.state.startedAt as number))
})
```

---

### `session()` middleware

Per-user state storage with pluggable backends.

```ts
interface MySession { count: number }
type Ctx = Context & { session: MySession }

bot.use(session<MySession, Ctx>({
  defaultSession: () => ({ count: 0 }),
}))

bot.on('message_created', (ctx) => {
  ctx.session.count++
})
```

Key features:
- Default in-memory store (`MemorySessionStore`) with optional TTL in milliseconds.
- `SyncSessionStore<T>` / `AsyncSessionStore<T>` interfaces for custom backends (Redis, SQLite, ...).
- Concurrent-request safety: parallel updates with the same key share a single cached object via reference counting.
- Default session key: `"${user_id}:${chat_id}"`. When either part is missing then `ctx.session = undefined` and the update passes through unchanged.
- Configurable `property` name (defaults to `"session"`), so multiple session stores can co-exist on the same context.

---

### Scenes / `Stage` / `WizardScene`

Multi-state dialogue management.

```ts
const greeter = new BaseScene<Ctx>('greeter')
greeter.enter((ctx) => ctx.reply('What is your name?'))
greeter.on('message_created', async (ctx) => {
  await ctx.reply(`Hello, ${ctx.message?.body.text}!`)
  await ctx.scene.leave()
})

const stage = new Stage<Ctx>([greeter])
bot.use(session())
bot.use(stage)
bot.command('start', (ctx) => ctx.scene.enter('greeter'))
```

`WizardScene` for linear step-by-step flows:

```ts
const wizard = new WizardScene<Ctx>(
  'reg',
  async (ctx) => { await ctx.reply('Name?'); ctx.wizard.next() },
  async (ctx) => {
    ctx.wizard.state.name = ctx.message?.body.text
    await ctx.scene.leave()
  },
)
```

`ctx.wizard` API: `.next()`, `.back()`, `.selectStep(n)`, `.cursor`, `.step`, `.state`.
`ctx.scene` API: `.enter(id, state?, silent?)`, `.leave()`, `.reenter()`, `.reset()`, `.current`, `.state`, `.session`.

Static shortcuts: `Stage.enter(id)`, `Stage.leave()`, `Stage.reenter()` — return ready-to-use handler functions.

Scene TTL: pass `ttl` (seconds) to `BaseScene` options or `Stage` options to auto-expire sessions.

---

### `Router`

Route-based dispatcher as a middleware:

```ts
const router = new Router<Ctx>((ctx) => {
  if (ctx.updateType === 'message_created') return { route: 'msg' }
  if (ctx.updateType === 'message_callback') return { route: 'cb' }
  return null
})
router.on('msg', handleMessage)
router.on('cb', handleCallback)
router.otherwise(fallback)
bot.use(router)
```

The routing function can optionally return a `state` map that gets merged into `ctx.state` before the handler runs.

---

### Advanced `Composer` methods

New instance methods:

| Method | Description |
|---|---|
| `drop(pred)` | Drop update (skip `next`) when predicate returns `true` |
| `fork(mw)` | Run middleware in background in parallel with the main chain |
| `tap(mw)` | Run as side-effect, always continue afterward |
| `lazy(fn)` | Create middleware lazily per update from a factory function |
| `branch(pred, t, f)` | Select `t` or `f` middleware based on a (possibly async) predicate |
| `optional(pred, ...mw)` | Run only when predicate is truthy, otherwise pass through |
| `dispatch(routeFn, map)` | Route to one of named handlers |
| `help(...mw)` | Shorthand for `command('help', ...)` |
| `settings(...mw)` | Shorthand for `command('settings', ...)` |

New static factories: `Composer.fork`, `Composer.tap`, `Composer.lazy`, `Composer.log(logFn?)`,
`Composer.catch(errorHandler, ...fns)`, `Composer.branch`, `Composer.optional`, `Composer.drop`,
`Composer.dispatch`, `Composer.passThru<C>()`, `Composer.unwrap(mw)`, `Composer.reply(...args)`.

`Triggers<Ctx>` (used by `.command()`, `.hears()`, `.action()`) now also accepts context-aware functions `TriggerFn<Ctx>`:

```ts
type TriggerFn<Ctx> = (value: string, ctx: Ctx) => RegExpExecArray | null
```

---

### Filter combinators (`filters.ts`)

New typed guards and combinators:

```ts
import { anyOf, allOf, messageEdited, messageCallback } from '@maxhub/max-bot-api'

// Logical OR — passes if at least one filter matches
bot.on(anyOf(messageEdited, messageCallback), handler)

// Logical AND — passes only when all filters match
bot.on(allOf(createdMessageBodyHas('text'), myGuard), handler)

// anyOf/allOf also accept plain UpdateType strings
bot.on(anyOf('message_created', 'message_edited'), handler)
```

---

### `fmt` — text formatting helpers

```ts
import { fmt } from '@maxhub/max-bot-api'

// Markdown (format: 'markdown')
ctx.reply(
  `${fmt.bold('Hello')} ${fmt.italic('world')}!\n` +
  `Your input: ${fmt.escape(userText)}`,
  { format: 'markdown' },
)

// HTML (format: 'html')
ctx.reply(
  fmt.boldHtml('Important: ') + fmt.escapeHtml(userInput),
  { format: 'html' },
)
```

Full Markdown set: `bold`, `italic`, `strikethrough`, `code`, `pre(text, lang?)`, `link(text, url)`, `escape`.
Full HTML set: `boldHtml`, `italicHtml`, `underlineHtml`, `strikethroughHtml`, `codeHtml`, `preHtml(text, lang?)`, `linkHtml(text, url)`, `escapeHtml`.

---

### `Keyboard.inlineKeyboard` — auto-layout

```ts
// Flat array auto-split into rows of 2
Keyboard.inlineKeyboard(
  [btn1, btn2, btn3, btn4],
  { columns: 2 },
)

// Custom wrap predicate
Keyboard.inlineKeyboard(buttons, {
  wrap: (btn, _index, currentRow) => currentRow.length >= 3,
})

// Buttons with hide: true are automatically filtered out
Keyboard.inlineKeyboard([
  Keyboard.button.callback('Public', 'pub'),
  { ...Keyboard.button.callback('Admin only', 'adm'), hide: !isAdmin },
])
```

---

### Bug fixes

**`src/core/helpers/upload.ts`** — three compatibility fixes for `@types/node@^25` (stricter `Buffer<ArrayBufferLike>` generics):

- `body: chunk` → `body: typeof chunk === 'string' ? chunk : new Uint8Array(chunk)`
- `source instanceof Buffer` → `Buffer.isBuffer(source)`
- `new Blob([file.buffer])` → `new Blob([new Uint8Array(file.buffer)])`

---

## Files changed

```
src/context.ts                   + ctx.state
src/filters.ts                   + anyOf, allOf, messageEdited, messageCallback
src/composer.ts                  + 9 new instance methods, TriggerFn support, new static factories
src/session.ts                   NEW
src/router.ts                    NEW
src/format.ts                    NEW
src/core/helpers/keyboard.ts     + buildKeyboard helper, two inlineKeyboard overloads, hide support
src/core/helpers/upload.ts       fix: Buffer compatibility with @types/node@25
src/scenes/base.ts               NEW
src/scenes/context.ts            NEW
src/scenes/stage.ts              NEW
src/scenes/wizard/context.ts     NEW
src/scenes/wizard/index.ts       NEW
src/scenes/index.ts              NEW
src/index.ts                     + re-exports of all new modules
examples/session-bot.ts          NEW
examples/wizard-bot.ts           NEW
```

No breaking changes. No new production dependencies.

---

## Testing

```bash
cd max-bot-api-client-ts
npm install
npm run build   # tsc — 0 errors
```
