### PR TITLE
fix: конечный retry с backoff и AbortSignal для attachment.not.ready

### DIFF
--- a/docs/02-listen-and-respond.md
+++ b/docs/02-listen-and-respond.md
@@ -70,6 +70,24 @@ console.log(message.body.mid);
 > });
 > ```
 
+### Отмена отправки
+Методы `sendMessageToChat` и `sendMessageToUser` поддерживают `AbortSignal` для отмены запроса. Это полезно, когда сервер долго обрабатывает вложение (`attachment.not.ready`) и вы хотите прервать ожидание:
+```typescript
+const controller = new AbortController();
+
+// Отменить через 30 секунд
+setTimeout(() => controller.abort(), 30_000);
+
+await bot.api.sendMessageToChat(54321, 'Текст', {
+  attachments: [image.toJson()],
+  signal: controller.signal,
+});
+```
+
+> ℹ️ При получении ошибки `attachment.not.ready` SDK автоматически повторяет
+> запрос до 10 раз с экспоненциальной задержкой (1 с, 2 с, 4 с, ...).
+> Если передан `signal`, повторы прекращаются при его отмене.
+
 Или воспользоваться методом контекста `reply`:
 ```typescript
 bot.hears('ping', async (ctx) => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -71,11 +71,12 @@ export class Api {
     text: string,
     extra?: SendMessageExtra,
   ) => {
+    const { signal, ...rest } = extra ?? {};
     const { message } = await this.raw.messages.send({
       chat_id: chatId,
       text,
-      ...extra,
-    });
+      ...rest,
+    }, { signal });
     return message;
   };
 
@@ -84,11 +85,12 @@ export class Api {
     text: string,
     extra?: SendMessageExtra,
   ) => {
+    const { signal, ...rest } = extra ?? {};
     const { message } = await this.raw.messages.send({
       user_id: userId,
       text,
-      ...extra,
-    });
+      ...rest,
+    }, { signal });
     return message;
   };
 

--- a/src/core/network/api/base-api.ts
+++ b/src/core/network/api/base-api.ts
@@ -6,7 +6,7 @@ import type { ApiMethods } from './modules/types';
 type ApiCallFn<HTTPMethod extends keyof ApiMethods> = <Method extends keyof ApiMethods[HTTPMethod]>(
   method: Method,
   // @ts-ignore
-  options: ApiMethods[HTTPMethod][Method]['req']
+  options: ApiMethods[HTTPMethod][Method]['req'] & { signal?: AbortSignal }
   // @ts-ignore
 ) => Promise<ApiMethods[HTTPMethod][Method]['res']>;
 

--- a/src/core/network/api/client.ts
+++ b/src/core/network/api/client.ts
@@ -14,7 +14,8 @@ export type ReqOptions = {
   method?: HTTPMethod;
   body?: object | null,
   query?: Record<string, string | number | boolean | null | undefined>,
-  path?: Record<string, string | number>
+  path?: Record<string, string | number>,
+  signal?: AbortSignal,
 };
 
 type CallOptions = {
@@ -49,6 +50,9 @@ export const createClient = (token: string, options: ClientOptions = {}) => {
 
     const init: RequestInit = { ...getResponseInit(callOptions?.body), method: httpMethod };
     init.headers = { ...init.headers, Authorization: token };
+    if (callOptions.signal) {
+      init.signal = callOptions.signal;
+    }
 
     const res = await fetch(url.href, init);
 

--- a/src/core/network/api/modules/messages/api.ts
+++ b/src/core/network/api/modules/messages/api.ts
@@ -1,4 +1,5 @@
 import { setTimeout } from 'node:timers/promises';
+import createDebug from 'debug';
 import { MaxError } from '../../error';
 import { BaseApi } from '../../base-api';
 import type {
@@ -10,6 +11,14 @@ import type {
   SendMessageResponse,
 } from '../types';
 import type { SendMessageDTO, DeleteMessageDTO } from './types';
+
+const debug = createDebug('one-me:messages');
+
+/** Максимальное количество повторов при ошибке attachment.not.ready */
+const ATTACHMENT_NOT_READY_MAX_RETRIES = 10;
+
+/** Начальная задержка между повторами (мс). Удваивается после каждой попытки. */
+const ATTACHMENT_NOT_READY_BASE_DELAY = 1_000;
 
 export class MessagesApi extends BaseApi {
   get = async ({ ...query }: FlattenReq<GetMessagesDTO>): Promise<GetMessagesResponse> => {
@@ -24,26 +33,53 @@ export class MessagesApi extends BaseApi {
     });
   };
 
-  send = async ({
-    chat_id, user_id, disable_link_preview, ...body
-  }: FlattenReq<SendMessageDTO>): Promise<SendMessageResponse> => {
-    try {
-      return await this._post('messages', {
-        body,
-        query: { chat_id, user_id, disable_link_preview },
-      });
-    } catch (err) {
-      if (err instanceof MaxError) {
-        if (err.code === 'attachment.not.ready') {
-          console.log('Attachment not ready');
-          await setTimeout(1000);
-          return this.send({
-            chat_id, user_id, disable_link_preview, ...body,
-          });
+  send = async (
+    {
+      chat_id, user_id, disable_link_preview, ...body
+    }: FlattenReq<SendMessageDTO>,
+    options?: { signal?: AbortSignal },
+  ): Promise<SendMessageResponse> => {
+    const signal = options?.signal;
+    let lastError: MaxError | undefined;
+
+    for (
+      let attempt = 0;
+      attempt < ATTACHMENT_NOT_READY_MAX_RETRIES;
+      attempt += 1
+    ) {
+      signal?.throwIfAborted();
+
+      try {
+        return await this._post('messages', {
+          body,
+          query: { chat_id, user_id, disable_link_preview },
+          signal,
+        });
+      } catch (err) {
+        if (
+          !(err instanceof MaxError)
+          || err.code !== 'attachment.not.ready'
+        ) {
+          throw err;
         }
+        lastError = err;
+        const delay = ATTACHMENT_NOT_READY_BASE_DELAY * (2 ** attempt);
+        debug(
+          'Attachment not ready (attempt %d/%d), retrying in %dms',
+          attempt + 1,
+          ATTACHMENT_NOT_READY_MAX_RETRIES,
+          delay,
+        );
+        await setTimeout(delay, undefined, { signal });
       }
-      throw err;
     }
+
+    throw lastError ?? new MaxError(500, {
+      code: 'attachment.not.ready',
+      message: `Attachment not ready after ${
+        ATTACHMENT_NOT_READY_MAX_RETRIES
+      } retries`,
+    });
   };
 
   edit = async ({ message_id, ...body }) => {

--- a/src/core/network/api/modules/messages/types.ts
+++ b/src/core/network/api/modules/messages/types.ts
@@ -44,7 +44,9 @@ export type SendMessageDTO = {
   }
 };
 
-export type SendMessageExtra = Omit<FlattenReq<SendMessageDTO>, 'chat_id' | 'user_id' | 'text'>;
+export type SendMessageExtra = Omit<FlattenReq<SendMessageDTO>, 'chat_id' | 'user_id' | 'text'> & {
+  signal?: AbortSignal;
+};
 
 export type SendMessageResponse = {
   message: Message


### PR DESCRIPTION
## Проблема

При отправке сообщения с вложением сервер может вернуть ошибку `attachment.not.ready`, если файл ещё обрабатывается. Текущая реализация `MessagesApi.send` обрабатывает это бесконечной рекурсией без лимита попыток:

```typescript
if (err.code === 'attachment.not.ready') {
  console.log('Attachment not ready');
  await setTimeout(1000);
  return this.send({ ... }); // бесконечная рекурсия
}
```

Это приводит к трём проблемам:

1. **Утечка ресурсов.** Если потребитель прерывает ожидание (например, через таймаут), исходный промис `send()` продолжает рекурсивно вызывать API бесконечно. Эти «зомби»-промисы невозможно остановить снаружи, и они живут до завершения процесса.

2. **`console.log` в библиотеке.** Прямой вывод в `console.log` ломает вывод потребителям (прогресс-бары, структурированные логи). Остальные модули SDK используют `debug`.

3. **Отсутствие backoff.** Фиксированная задержка 1 с при каждой попытке не снижает нагрузку на сервер при длительной обработке тяжёлых файлов.

### Пример

Бот загружает видео через `upload.video()`, затем отправляет сообщение с полученным токеном. Сервер отвечает `attachment.not.ready` - возможно видео ещё обрабатывается. SDK начинает бесконечный retry-цикл. Бот, не дождавшись ответа, прерывает ожидание по таймауту и перезагружает видео. Повторная отправка проходит успешно. Но первый `send()` продолжает рекурсивно стучаться в API в фоне - бесконечно, без возможности остановки. В логах после завершения импорта видны сотни строк `Attachment not ready`, генерируемые «зомби»-промисами.

> То, что повторная загрузка того же видео завершается быстро (а первая может зависнуть навсегда), может указывать на проблему на стороне сервера — возможно, первый запрос «застревает» в обработке, а повторный уже использует закешированный результат. Тем не менее, клиент не должен зависать бесконечно в любом случае.


## Решение

### Конечный цикл с backoff

Рекурсия заменена на `for`-цикл с лимитом 10 попыток и экспоненциальной задержкой (1 с → 2 с → 4 с → ... → 512 с). При исчерпании попыток выбрасывается `MaxError` с кодом `attachment.not.ready`.

### `debug` вместо `console.log`

Логирование через `debug('one-me:messages')`, как во всех остальных модулях SDK.

### Поддержка `AbortSignal`

`sendMessageToChat` и `sendMessageToUser` теперь принимают опциональный `signal: AbortSignal` в `extra`. Signal:
- Проверяется перед каждой итерацией (`signal.throwIfAborted()`)
- Отменяет задержку между попытками (`node:timers/promises setTimeout` с `{ signal }`)
- Передаётся в `fetch` для реальной отмены HTTP-запроса

Это позволяет потребителю гарантированно прервать ожидание без утечки ресурсов.

## Обратная совместимость

Все изменения полностью обратно совместимы:
- `signal` опционален - без него поведение не меняется (кроме конечного цикла вместо бесконечного)
- Публичные API-сигнатуры расширены, не изменены
- При исчерпании попыток выбрасывается тот же `MaxError` с тем же кодом
